### PR TITLE
Remove torii redirect dispatching

### DIFF
--- a/config/dispatcher/dispatcher-prod.ex
+++ b/config/dispatcher/dispatcher-prod.ex
@@ -282,10 +282,6 @@ defmodule Dispatcher do
   # frontend layer
   ###############################################################
 
-  match "/authorization/callback/*_path", %{ accept: [:html], layer: :api } do
-      Proxy.forward conn, [], "http://frontend/torii/redirect.html"
-  end
-
   match "/assets/*path", %{ layer: :api } do
     Proxy.forward conn, path, "http://frontend/assets/"
   end

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -280,10 +280,6 @@ defmodule Dispatcher do
   # frontend layer
   ###############################################################
 
-  match "/authorization/callback/*_path", %{ accept: [:html], layer: :api } do
-      Proxy.forward conn, [], "http://frontend/torii/redirect.html"
-  end
-
   match "/assets/*path", %{ layer: :api } do
     Proxy.forward conn, path, "http://frontend/assets/"
   end


### PR DESCRIPTION
This dispatcher rule doesn't fit with the newer version of the ember-acmidm-login integration, see https://github.com/lblod/frontend-worship-organizations/pull/7 