### PR TITLE
Improve performances of the consumers and dispatching

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     restart: always
     logging: *default-logging
   db:
-    image: semtech/mu-authorization:feature-service-roam-r1
+    image: semtech/mu-authorization:feature-service-roam-r1.1
     environment:
       MU_SPARQL_ENDPOINT: "http://triplestore:8890/sparql"
       ERROR_ON_UNWRITTEN_DATA: "true"
@@ -71,7 +71,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:feature-construct-based-fetches
+    image: semtech/mu-cl-resources:1.22.2
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     links:


### PR DESCRIPTION
OP-2595

Since we received a big amount of data, the stack is being unable to consume and dispatch properly such an amount of incoming triples.
Strategies to improve this are:
- Bumping core services to help a bit
- Upgrading the consumer to a more recent version
- (?) Bump mu-auth-sudo in the consumer to be able to retry queries (?)
- (?) Move the responsibility of the dispatching to the consumer if feasible (?)