### PR TITLE
Feat/controle env

### DIFF
--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -234,16 +234,14 @@ defmodule Dispatcher do
 
 
   match "/mock/sessions/*path", %{ accept: [:any], layer: :api} do
-    send_resp( conn, 404, "{\"error\": {\"code\": 404}")
+    Proxy.forward conn, path, "http://controle-login-proxied/sessions/"
+
    end
 
   match "/sessions/*path", %{ accept: [:any], layer: :api} do
     Proxy.forward conn, path, "http://controle-login/sessions/"
   end
-  
-  match "/controller-login/*path", %{ layer: :api } do
-    Proxy.forward conn, path, "http://controle-login-proxied/"
-  end
+ 
 
   ###############################################################
   # API SERVICES

--- a/config/dispatcher/dispatcher-controle.ex
+++ b/config/dispatcher/dispatcher-controle.ex
@@ -1,0 +1,332 @@
+defmodule Dispatcher do
+  use Matcher
+
+  define_accept_types [
+    html: ["text/html", "application/xhtml+html"],
+    json: ["application/json", "application/vnd.api+json"],
+    upload: ["multipart/form-data"],
+    sparql_json: ["application/sparql-results+json"],
+    any: [ "*/*" ],
+  ]
+
+  define_layers [ :api_services, :api, :frontend, :not_found ]
+
+
+  ###############################################################
+  # domain.json
+  ###############################################################
+
+  match "/people/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/people/"
+  end
+
+  match "/agents-in-position/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/agents-in-position/"
+  end
+
+  match "/posts/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/posts/"
+  end
+
+  match "/mandatories/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/mandatories/"
+  end
+
+  match "/mandatory-status-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/mandatory-status-codes/"
+  end
+
+  match "/worship-mandatories/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/worship-mandatories/"
+  end
+
+  match "/half-elections/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/half-elections/"
+  end
+
+  match "/contact-points/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/contact-points/"
+  end
+
+  match "/mandates/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/mandates/"
+  end
+
+  match "/board-positions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/board-positions/"
+  end
+
+  match "/board-position-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/board-position-codes/"
+  end
+
+  match "/agents/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/agents/"
+  end
+
+  match "/agent-status-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/agent-status-codes/"
+  end
+
+  match "/roles/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/roles/"
+  end
+
+  match "/organizations/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/organizations/"
+  end
+
+  match "/administrative-units/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/administrative-units/"
+  end
+
+  match "/administrative-unit-classification-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/administrative-unit-classification-codes/"
+  end
+
+  match "/worship-administrative-units/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/worship-administrative-units/"
+  end
+
+  match "/worship-services/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://resource/worship-services/" # DISABLE CACHING FOR NOW (BUG OP-1404)
+  end
+
+  match "/recognized-worship-types/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/recognized-worship-types/"
+  end
+
+  match "/central-worship-services/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/central-worship-services/"
+  end
+
+  match "/representative-bodies/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/representative-bodies/"
+  end
+
+  match "/governing-bodies/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/governing-bodies/"
+  end
+
+  match "/governing-body-classification-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/governing-body-classification-codes/"
+  end
+
+  match "/local-involvements/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/local-involvements/"
+  end
+
+  match "/identifiers/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/identifiers/"
+  end
+
+  match "/structured-identifiers/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/structured-identifiers/"
+  end
+
+  match "/addresses/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/addresses/"
+  end
+
+  match "/sites/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/sites/"
+  end
+
+  match "/change-events/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/change-events/"
+  end
+
+  match "/change-event-types/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/change-event-types/"
+  end
+
+  match "/change-event-results/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/change-event-results/"
+  end
+
+  match "/organization-status-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/organization-status-codes/"
+  end
+
+  match "/locations/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/locations/"
+  end
+
+  match "/involvement-types/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/involvement-types/"
+  end
+
+  match "/ministers/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/ministers/"
+  end
+
+  match "/minister-conditions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/minister-conditions/"
+  end
+
+  match "/dates-of-birth/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/dates-of-birth/"
+  end
+
+  match "/nationalities/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/nationalities/"
+  end
+
+  match "/gender-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/gender-codes/"
+  end
+  match "/concepts/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/concepts/"
+  end
+
+  match "/minister-positions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/minister-positions/"
+  end
+
+  match "/minister-position-functions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/minister-position-functions/"
+  end
+
+  match "/financing-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/financing-codes/"
+  end
+
+  match "/minister-condition-criterions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/minister-condition-criterions/"
+  end
+
+  match "/document-types-criterions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/document-types-criterions/"
+  end
+
+  match "/site-types/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/site-types/"
+  end
+
+  match "/request-reasons/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/request-reasons/"
+  end
+
+  match "/decisions/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/decisions/"
+  end
+
+  match "/decision-activities/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/decision-activities/"
+  end
+
+  match "/request-reasons/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/request-reasons/"
+  end
+  ###############
+  # LOGIN
+  ###############
+
+  match "/accounts", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, [], "http://resource/accounts/"
+  end
+  match "/accounts/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://accountdetail/accounts/"
+  end
+  match "/groups/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://resource/groups/"
+  end
+
+
+  match "/mock/sessions/*path", %{ accept: [:any], layer: :api} do
+    send_resp( conn, 404, "{\"error\": {\"code\": 404}")
+   end
+
+  match "/sessions/*path", %{ accept: [:any], layer: :api} do
+    Proxy.forward conn, path, "http://controle-login/sessions/"
+  end
+  
+  match "/controller-login/*path", %{ layer: :api } do
+    Proxy.forward conn, path, "http://controle-login-proxied/"
+  end
+
+  ###############################################################
+  # API SERVICES
+  ###############################################################
+
+  get "/uri-info/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    forward conn, path, "http://uri-info/"
+  end
+
+  match "/person-information-requests/*path", %{ accept: [:any], layer: :api} do
+    forward conn, path, "http://privacy/person-information-requests"
+  end
+
+  match "/person-information-ask/*path", %{ accept: [:any], layer: :api}  do
+    forward conn, path, "http://privacy/person-information-ask/"
+  end
+  #################################################################
+  # ERROR REPORT
+  #################################################################
+
+  match "/error-reports/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    forward conn, path, "http://error-report-service/error-reports/"
+  end
+
+  #################################################################
+  # FILES
+  #################################################################
+
+  get "/files/:id/download", %{ accept: [:any], } do
+    Proxy.forward conn, [], "http://file/files/" <> id <> "/download"
+  end
+
+  get "/files/*path" , %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/files/"
+  end
+
+  #################################################################
+  # DCAT
+  #################################################################
+
+  get "/datasets/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/datasets/"
+  end
+
+  get "/distributions/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    Proxy.forward conn, path, "http://cache/distributions/"
+  end
+
+  ###############################################################
+  # frontend layer
+  ###############################################################
+
+  match "/assets/*path", %{ layer: :api } do
+    Proxy.forward conn, path, "http://controle-frontend/assets/"
+  end
+
+  match "/@appuniversum/*path", %{ layer: :api } do
+    Proxy.forward conn, path, "http://controle-frontend/@appuniversum/"
+  end
+
+  match "/*path", %{ accept: [:html], layer: :api } do
+    Proxy.forward conn, [], "http://controle-frontend/index.html"
+  end
+
+  match "/*_path", %{ layer: :frontend } do
+    Proxy.forward conn, [], "http://controle-frontend/index.html"
+  end
+
+  ###############################################################
+  # sparql endpoint
+  ###############################################################
+
+  post "/sparql/*path", %{ layer: :api_services, accept: %{ sparql_json: true } } do
+    forward conn, path, "http://db:8890/sparql/"
+  end
+
+  ###############################################################
+  # errors
+  ###############################################################
+
+  match "/*_path", %{ accept: [:any], layer: :not_found} do
+    send_resp( conn, 404, "{\"error\": {\"code\": 404}")
+  end
+
+
+end

--- a/config/migrations/2023/20231130153808-add-controller-wop.sparql
+++ b/config/migrations/2023/20231130153808-add-controller-wop.sparql
@@ -1,0 +1,13 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/bestuurseenheden/3183ade3-7ee8-409c-8394-296b1fbfe478> a besluit:Bestuurseenheid ;
+       mu:uuid "3183ade3-7ee8-409c-8394-296b1fbfe478" ;
+       skos:prefLabel "Agentschap Binnenlands Bestuur" ;
+       dcterms:identifier "OVO001835" .
+  }
+}

--- a/config/migrations/2023/20231130153808-add-controller-wop.sparql
+++ b/config/migrations/2023/20231130153808-add-controller-wop.sparql
@@ -8,6 +8,11 @@ INSERT DATA {
     <http://data.lblod.info/id/bestuurseenheden/3183ade3-7ee8-409c-8394-296b1fbfe478> a besluit:Bestuurseenheid ;
        mu:uuid "3183ade3-7ee8-409c-8394-296b1fbfe478" ;
        skos:prefLabel "Agentschap Binnenlands Bestuur" ;
+       <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>;
+       
        dcterms:identifier "OVO001835" .
+
+
+       
   }
 }

--- a/config/nginx-dev/Dockerfile
+++ b/config/nginx-dev/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginx
+ARG MOCK_DOMAIN
+RUN openssl req -x509 -nodes -days 365 -subj "/C=CA/ST=QC/O=Company, Inc./CN=${MOCK_DOMAIN}" -addext "subjectAltName=DNS:${MOCK_DOMAIN}" -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt;
+RUN ["nginx"]

--- a/config/nginx-dev/http/controle.conf
+++ b/config/nginx-dev/http/controle.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name controle.organisaties.lokaalbestuur.lblod.info;
+    location / {
+        return 301 https://$host$request_uri;
+    }    
+}
+server {
+    listen 443 ssl http2;
+    server_name controle.organisaties.lokaalbestuur.lblod.info;
+    expires -1;
+    add_header Cache-Control "public, no-transform";
+    add_header Pragma public;
+    ssl_certificate /etc/ssl/certs/nginx-selfsigned.crt;
+    ssl_certificate_key /etc/ssl/private/nginx-selfsigned.key;
+    #include /etc/proxy/options-ssl-nginx.conf;
+   # ssl_dhparam /etc/proxy/ssl-dhparams.pem;
+    location / {
+	      proxy_buffer_size   128k;
+	      proxy_buffers   4 256k;
+	      proxy_busy_buffers_size   256k;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_pass http://controle-identifier;
+    }
+}

--- a/config/nginx-dev/nginx.conf
+++ b/config/nginx-dev/nginx.conf
@@ -1,0 +1,32 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}
+


### PR DESCRIPTION
OP-2821

To test:

- add the following to your override (make sure to change the secret properties with the one in the server, or ask me privately) :
```yml
 controle-identifier:
    image: semtech/mu-identifier:1.10.1
    environment:
      VIRTUAL_HOST: "controle.organisaties.lokaalbestuur.lblod.info"
      LETSENCRYPT_HOST: "controle.organisaties.lokaalbestuur.lblod.info"
      LETSENCRYPT_EMAIL: "support+servers@redpencil.io"
      MU_ENCRYPTION_SALT: "encryptionsalt"
      MU_SIGNING_SALT: "signingsalt"
      MU_SECRET_KEY_BASE: "7669040919139488377804439778314176690409191394883778044397783141"
    links:
      - controle-dispatcher:dispatcher
  controle-dispatcher:
    image: semtech/mu-dispatcher:2.1.0-beta.2
    volumes:
         - ./config/dispatcher/dispatcher-controle.ex:/config/dispatcher.ex
    labels:
      - "logging=true"
  controle-frontend:
    image: lblod/frontend-worship-organizations:feature-controle-env
    volumes:
      - ./config/frontend/add-x-frame-options-header.conf:/config/add-x-frame-options.conf
    environment:
      EMBER_OAUTH_API_KEY: "fc0d3dcf-5972-4ef1-99c2-23758e9e7a06"
      EMBER_OAUTH_API_SCOPE: "openid vo profile rrn abb_orgcontactgegevens"
      EMBER_OAUTH_API_BASE_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/auth"
      EMBER_OAUTH_API_LOGOUT_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/logout"
      EMBER_OAUTH_API_REDIRECT_URL: "https://controle.organisaties.lokaalbestuur.lblod.info/controller-login"
      EMBER_OAUTH_SWITCH_URL: "https://controle.organisaties.lokaalbestuur.lblod.info/switch-login"
      EMBER_CONTROLLER_LOGIN: "true"
    labels:
      - "logging=true"
    restart: always
  controle-login:
    image: lblod/acmidm-login-service:0.9.2
    environment:
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://controle.organisaties.lokaalbestuur.lblod.info/controller-login"
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "fc0d3dcf-5972-4ef1-99c2-23758e9e7a06"
      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_orgcontactgegevens_rol_1d"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "secret"
      DEBUG_LOG_TOKENSETS: "yes"
    links:
      - db:database
  controle-login-proxied:
    image: lblod/controller-login
    environment:
      ACM_IDM_LOGIN_ENDPOINT: "http://controle-login"
      CONTROLLER_ROLE: "ControllerWOP"
    links:
      - db:database
  tlsproxy:
    restart: always
    build:
      context: ./config/nginx-dev/.
      args:
        MOCK_DOMAIN: organisaties.lokaalbestuur.lblod.info
    ports:
      - "443:443"
    volumes:
      - ./config/nginx-dev/http:/etc/nginx/conf.d
      - ./config/nginx-dev/nginx.conf:/etc/nginx/nginx.conf
 ```

- drc up -d
- add to your /etc/hosts :
```
127.0.1.1       controle.organisaties.lokaalbestuur.lblod.info
```
- go to `https://controle.organisaties.lokaalbestuur.lblod.info`
- login using acmidm (you need to have the ControllerWOP role)
- you should be redirected to /controller-login page
- check video below to see how it works:


https://github.com/lblod/app-worship-organizations/assets/3816305/6f2b3452-4646-4752-95f7-673843d64198


