### PR TITLE
chore: additional environment setting for worship sensitive consumer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,9 @@ services:
     environment:
       DCR_SERVICE_NAME: "worship-services-sensitive-consumer"
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+
+      DCR_SYNC_LOGIN_ENDPOINT: "https://loket.lblod.info/sync/worship-services-sensitive/login"
+      DCR_SECRET_KEY: "<override with secret key>"
       DCR_SYNC_FILES_PATH: "/sync/worship-services-sensitive/files"
       DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/WorshipServicesSensitiveCacheGraphDump"
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/wsSensitive"


### PR DESCRIPTION
This adds example entries for `DCR_SYNC_LOGIN_ENDPOINT` and `DCR_SECRET_KEY`
environment settings for the worship sensitive consumer. The example value for
`DCR_SYNC_LOGIN_ENDPOINT` was chosen to match the value for `DCR_SYNC_BASE_URL`.

These environment settings need to be set correctly for the worship sensitive
consumer. Including examples in the `docker-compose.yml` makes this more
explicit.