### PR TITLE
Fix deletes without inserts not being handled by positions dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   - Update regular database config (`virtuoso.ini`)
   - Add missing compose keys. [DL-6490]
   - Reorganize delta consumers config to harmonize with the ecosystem
+  - Fix bug in positions-dispatcher
 ### Deploy Notes
 The production instance already has the updated production config. This is intented for local, DEV and QA instances that may be using the regular configuration:
 ```
@@ -10,6 +11,11 @@ drc restart triplestore && drc logs -ft --tail=200 triplestore
 ```
 ```
 drc up -d triplestore error-report-service privacy worship-services-sensitive-consumer worship-posts-consumer
+```
+and for the positions dispatcher fix:
+```
+drc restart migrations
+drc up -d positions-dispatcher worship-posts-consumer worship-services-sensitive-consumer
 ```
 ## 1.2.6 (2025-02-26)
 ### Backend

--- a/config/migrations/2025/20250404142800-remove-dispatched-data-deleted-by-consumer.sparql
+++ b/config/migrations/2025/20250404142800-remove-dispatched-data-deleted-by-consumer.sparql
@@ -1,0 +1,17 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+
+  FILTER(STRSTARTS(STR(?g), "http://mu.semte.ch/graphs/organizations/"))
+
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/ingest> {
+      ?s ?p ?o .
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
     restart: always
     logging: *default-logging
   positions-dispatcher:
-    image: lblod/worship-positions-graph-dispatcher-service:1.1.0
+    image: lblod/worship-positions-graph-dispatcher-service:1.1.0 # TODO Bump when https://github.com/lblod/worship-positions-graph-dispatcher-service/pull/4 released
     environment:
       DIRECT_DATABASE_ENDPOINT: "http://triplestore:8890/sparql"
     links:
@@ -194,11 +194,10 @@ services:
   # DELTAS
   ################################################################################
   worship-services-sensitive-consumer:
-    image: lblod/delta-consumer:0.1.1
+    image: lblod/delta-consumer:0.1.4
     environment:
       DCR_SERVICE_NAME: "worship-services-sensitive-consumer"
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
-
       DCR_SYNC_LOGIN_ENDPOINT: "https://loket.lblod.info/sync/worship-services-sensitive/login"
       DCR_SECRET_KEY: "<override with secret key>"
       DCR_SYNC_FILES_PATH: "/sync/worship-services-sensitive/files"
@@ -227,7 +226,7 @@ services:
     restart: always
     logging: *default-logging
   worship-posts-consumer:
-    image: lblod/delta-consumer:0.1.1
+    image: lblod/delta-consumer:0.1.4
     environment:
       DCR_SERVICE_NAME: "worship-posts-consumer"
       DCR_SYNC_BASE_URL: "https://organisaties.abb.lblod.info/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -169,7 +169,7 @@ services:
     restart: always
     logging: *default-logging
   positions-dispatcher:
-    image: lblod/worship-positions-graph-dispatcher-service:1.1.0 # TODO Bump when https://github.com/lblod/worship-positions-graph-dispatcher-service/pull/4 released
+    image: lblod/worship-positions-graph-dispatcher-service:1.1.1
     environment:
       DIRECT_DATABASE_ENDPOINT: "http://triplestore:8890/sparql"
     links:


### PR DESCRIPTION
# Context

[OP-3589]

Has to be tested together with https://github.com/lblod/worship-positions-graph-dispatcher-service/pull/4 , where you can find extensive testing instructions :)

This PR also brings in a migration to clean up data that was affected by the bug. So it's the triples that were deleted by the consumer, meaning the triples are gone in the ingest graph but are still there in the organization or public graphs. I checked the data, it seems to only affect the org graphs. This is why the public graph is left out from the migration.