### PR TITLE
chore: bump frontend to latest release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # Changelog
+## Unreleased
+### Frontend
+- Bump to [v1.2.4](https://github.com/lblod/frontend-worship-organizations/blob/v1.2.4/CHANGELOG.md#124-2025-06-26)
+### Deploy Notes
+```
+drc pull frontend; drc up -d frontend
+```
+
 ## 1.2.8 (2025-06-13)
-  - Bump frontend to v1.2.3 [DL-5635]
+- Bump frontend to v1.2.3 [DL-5635]
 
 ### Deploy Notes
-
 ```
 drc up -d frontend
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   frontend:
-    image: lblod/frontend-worship-organizations:1.2.3
+    image: lblod/frontend-worship-organizations:1.2.4
     volumes:
       - ./config/frontend/add-x-frame-options-header.conf:/config/add-x-frame-options.conf
     environment:


### PR DESCRIPTION
This bumps the frontend to the latest version containing a revert a previous fix that became unnecessary.