### PR TITLE
[OP-3826] Fix an issue where the "Geplande einddatum" wasn't shown for worshipmandatees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,20 @@
 - Bump acm-login service [DL-7346]
 - frontend [v1.4.0](https://github.com/lblod/frontend-worship-organizations/blob/1d10fa2420b31ef395aca3644fb1ade0b9e32e4c/CHANGELOG.md#140-2026-06-05) ,[v1.3.0](https://github.com/lblod/frontend-worship-organizations/blob/1d10fa2420b31ef395aca3644fb1ade0b9e32e4c/CHANGELOG.md#130-2026-05-12) 
 - Bump worship-positions-graph-dispatcher-service [DL-7344] [OP-3825]
+- Fix an issue where the "Geplande einddatum" wasn't shown for worship mandatees [OP-3826]
 
 ## Deploy notes
 ```
+drc restart migrations
 drc up -d login-dashboard login positions-dispatcher
 drc pull frontend && drc up -d frontend
-```
 
+# if OP-3825 was deployed before OP-3826
+drc exec positions-dispatcher curl -X POST "http://localhost/manual-dispatch?type=http://data.lblod.info/vocabularies/erediensten/EredienstMandataris"
+
+# If OP-3825 wasn't deployed yet
+drc exec positions-dispatcher curl -X POST "http://localhost/manual-dispatch"
+```
 
 ## 1.3.0 (2026-05-07)
 - Fix bug in delta-notification rules [OP-3796]

--- a/config/delta-consumers/worship-services-sensitive/mapping/queries/dl2op/pass/eredienst-mandataris.sparql
+++ b/config/delta-consumers/worship-services-sensitive/mapping/queries/dl2op/pass/eredienst-mandataris.sparql
@@ -7,7 +7,7 @@ CONSTRUCT {
   ?s a <http://data.lblod.info/vocabularies/erediensten/EredienstMandataris>;
     ?p ?o.
 
- FILTER (?p NOT IN (ch:startdatum, ch:eindedatum, ere:geplandeEinddatumAanstelling))
+ FILTER (?p NOT IN (ch:startdatum, ch:eindedatum))
 
  FILTER NOT EXISTS {
    ?s ?p "" .

--- a/config/migrations/2026/20260715115400-fix-planned-end-date.sparql
+++ b/config/migrations/2026/20260715115400-fix-planned-end-date.sparql
@@ -1,0 +1,10 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/ingest> {
+    ?s <http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling> ?o .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/landing-zone/worship-services-sensitive> {
+    ?s <http://data.lblod.info/vocabularies/erediensten/geplandeEinddatumAanstelling> ?o .
+  }
+}


### PR DESCRIPTION
The data existed in the DB but wasn't properly dispatched to the correct graphs

## Test instructions
### Issue reproduction
- set up your local stack with the development branch and sync data from the DEV environment
- Create a new mandataris in Loket DEV
- configure the worship-services-sensitive-consumer with the values from the DEV environment (links it to Loket DEV):
```
  worship-services-sensitive-consumer:
    environment:
      DCR_SYNC_BASE_URL: 'https://dev.loket.lblod.info/'
      DCR_SYNC_LOGIN_ENDPOINT: 'https://dev.loket.lblod.info/sync/worship-services-sensitive/login'
      DCR_SECRET_KEY: "snip, see server"
      DCR_CRON_PATTERN_DELTA_SYNC: '*/5 * * * *' # this is every minute 5
      DCR_LANDING_ZONE_DATABASE: "db"
      DCR_REMAPPING_DATABASE: "db"
      DCR_DISABLE_DELTA_INGEST: "false"
      DCR_DISABLE_INITIAL_SYNC: "false"
 ```
- Wait for the 5 minute cron timer and verify that the "Geplande einddatum" is missing in the local frontend after the data is synced

### Fix for new mandataris data
- check out this branch and run `drc restart worship-services-sensitive-consumer`
- repeat the mandataris creation flow and verify that "Geplande einddatum" is shown for the new mandataris in WOP

### Fixing existing incorrect data
- restart the migrations service
- start a manual dispatch: `docker compose exec positions-dispatcher curl -X POST "http://localhost/manual-dispatch?type=http://data.lblod.info/vocabularies/erediensten/EredienstMandataris"`
- Once done (which can take a while, I think) verify that all mandatees we created now display the geplande einddatum